### PR TITLE
KEYCLOAK-1305 Add possibility to change username

### DIFF
--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -198,6 +198,7 @@ module.controller('UserListCtrl', function($scope, realm, User) {
 module.controller('UserDetailCtrl', function($scope, realm, user, User, UserFederationInstances, $location, Dialog, Notifications) {
     $scope.realm = realm;
     $scope.create = !user.username;
+    $scope.editUsername = $scope.create;
 
     if ($scope.create) {
         $scope.user = { enabled: true, attributes: {} }
@@ -247,11 +248,12 @@ module.controller('UserDetailCtrl', function($scope, realm, user, User, UserFede
         } else {
             User.update({
                 realm: realm.realm,
-                userId: $scope.user.username
+                userId: user.username
             }, $scope.user, function () {
                 $scope.changed = false;
                 user = angular.copy($scope.user);
                 Notifications.success("Your changes have been saved to the user.");
+                $location.url("/realms/" + realm.realm + "/users/" + $scope.user.username);
             });
         }
     };

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
@@ -25,9 +25,17 @@
                 <div class="col-md-6">
                     <!-- Characters >,<,/,\ are forbidden in username -->
                     <input class="form-control" type="text" id="username" name="username" data-ng-model="user.username" autofocus
-                           required ng-pattern="/^[^\<\>\\\/]*$/" data-ng-readonly="!create">
+                           required ng-pattern="/^[^\<\>\\\/]*$/" data-ng-readonly="!editUsername">
                 </div>
             </div>
+            <div class="form-group clearfix block" data-ng-show="!create">
+                <label class="col-md-2 control-label" for="userEditUsername">Edit Username</label>
+                <div class="col-md-6">
+                    <input ng-model="editUsername" name="userEnabled" id="userEditUsername" onoffswitch />
+                </div>
+                <kc-tooltip>Switch on, if you want to edit the username.</kc-tooltip>
+            </div>
+
 
             <div class="form-group">
                 <label class="col-md-2 control-label" for="email">Email</label>

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -174,6 +174,7 @@ public class UsersResource {
     }
 
     private void updateUserFromRep(UserModel user, UserRepresentation rep) {
+        user.setUsername(rep.getUsername());
         user.setEmail(rep.getEmail());
         user.setFirstName(rep.getFirstName());
         user.setLastName(rep.getLastName());

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -320,4 +320,49 @@ public class UserTest extends AbstractClientTest {
         assertNull(user1.getAttributes());
     }
 
+    @Test
+    public void updateUserWithNewUsername() {
+        createUser();
+
+        UserResource user = realm.users().get("user1");
+        UserRepresentation userRep = user.toRepresentation();
+        userRep.setUsername("user11");
+        user.update(userRep);
+
+        userRep = realm.users().get("user11").toRepresentation();
+        assertEquals("user11", userRep.getUsername());
+    }
+
+    @Test
+    public void updateUserWithNewUsernameAccessingViaOldUsername() {
+        createUser();
+
+        try {
+            UserResource user = realm.users().get("user1");
+            UserRepresentation userRep = user.toRepresentation();
+            userRep.setUsername("user1");
+            user.update(userRep);
+
+            realm.users().get("user11").toRepresentation();
+            fail("Expected failure");
+        } catch (ClientErrorException e) {
+            assertEquals(404, e.getResponse().getStatus());
+        }
+    }
+
+    @Test
+    public void updateUserWithExistingUsername() {
+        createUsers();
+
+        try {
+            UserResource user = realm.users().get("username1");
+            UserRepresentation userRep = user.toRepresentation();
+            userRep.setUsername("username2");
+            user.update(userRep);
+            fail("Expected failure");
+        } catch (ClientErrorException e) {
+            assertEquals(409, e.getResponse().getStatus());
+        }
+    }
+
 }


### PR DESCRIPTION
Be able to change the username of a user in admin api and admin console. For admin console, there's a new "Edit Username" switch, to allow the modification of the username.
